### PR TITLE
Handle EOF gracefully

### DIFF
--- a/server.go
+++ b/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 )
 
@@ -52,6 +53,9 @@ func (server *Server) Run() error {
 		body, err := bufio.
 			NewReader(conn).
 			ReadString(byte(server.MessageDelimeter[0]))
+		if err == io.EOF {
+			return nil
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Newer versions of dredd close the socket before killing the hook handler. This
change prevents the handler from exiting with an error.
