### PR TITLE
Fix error with pointers that caused transactions to not be mutated

### DIFF
--- a/features/execution_order.feature
+++ b/features/execution_order.feature
@@ -28,8 +28,6 @@ Feature: Execution order
     """
     package main
     import (
-      "fmt"
-
       "github.com/snikch/goodman/hooks"
       trans "github.com/snikch/goodman/transaction"
     )
@@ -38,32 +36,60 @@ Feature: Execution order
         h := hooks.NewHooks()
         server := hooks.NewServer(h)
         h.BeforeAll(func(t []*trans.Transaction) {
-          fmt.Printf("%#v", t)
-          fmt.Println("before all modification")
+            if t[0].TestOrder == nil {
+                t[0].TestOrder = []string{"before all modification"}
+                } else {
+                    t[0].TestOrder = append(t[0].TestOrder, "before all modification")
+                }
         })
         h.BeforeEach(func(t *trans.Transaction) {
-          fmt.Printf("%#v", t)
-          fmt.Println("before each modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"before each modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "before each modification")
+                }
         })
         h.Before("/message > GET", func(t *trans.Transaction) {
-          fmt.Printf("%#v", t)
-          fmt.Println("before modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"before modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "before modification")
+                }
         })
         h.BeforeEachValidation(func(t *trans.Transaction) {
-          fmt.Printf("%#v", t)
-          fmt.Println("before each validation modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"before each validation modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "before each validation modification")
+                }
         })
         h.BeforeValidation("/message > GET", func(t *trans.Transaction) {
-          fmt.Println("before validation modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"before validation modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "before validation modification")
+                }
         })
         h.After("/message > GET", func(t *trans.Transaction) {
-          fmt.Println("after modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"after modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "after modification")
+                }
         })
         h.AfterEach(func(t *trans.Transaction) {
-          fmt.Println("after each modification")
+            if t.TestOrder == nil {
+                t.TestOrder = []string{"after each modification"}
+                } else {
+                    t.TestOrder = append(t.TestOrder, "after each modification")
+                }
         })
         h.AfterAll(func(t []*trans.Transaction) {
-          fmt.Println("after all modification")
+            if t[0].TestOrder == nil {
+                t[0].TestOrder = []string{"after all modification"}
+                } else {
+                    t[0].TestOrder = append(t[0].TestOrder, "after all modification")
+                }
         })
 
         server.Serve()

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -16,6 +16,8 @@ Feature: Failing a transaction
       """
       # My Api
       ## GET /message
+      + Request (text)
+        This prevents dredd bug
       + Response 200 (text/html;charset=utf-8)
           Hello World!
       """

--- a/features/failing_transaction.feature
+++ b/features/failing_transaction.feature
@@ -26,8 +26,6 @@ Feature: Failing a transaction
       """
       package main
       import (
-        "fmt"
-
         "github.com/snikch/goodman/hooks"
         trans "github.com/snikch/goodman/transaction"
       )
@@ -37,7 +35,6 @@ Feature: Failing a transaction
           server := hooks.NewServer(h)
           h.Before("/message > GET", func(t *trans.Transaction) {
               t.Fail = "Yay! Failed!"
-              fmt.Println("Yay! Failed!")
           })
           server.Serve()
           defer server.Listener.Close()

--- a/features/multiple_hookfiles.feature
+++ b/features/multiple_hookfiles.feature
@@ -90,7 +90,7 @@ Feature: Multiple hook files with a glob
       }
       """
     # When I run `go build -o hook_file_to_be_globed github.com/snikch/goodman/tmp/aruba`
-    When I run `dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language bin/goodman --hookfiles ./1/hookfile1 --hookfiles ./2/hookfile2`
+    When I run `../../node_modules/.bin/dredd ./apiary.apib http://localhost:4567 --server "ruby server.rb" --language bin/goodman --hookfiles ./1/hookfile1 --hookfiles ./2/hookfile2`
     Then the exit status should be 0
     And the output should contain:
       """

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -36,7 +36,7 @@ func NewHooks() *Hooks {
 }
 
 func (h *Hooks) RunBeforeAll(args []*trans.Transaction, reply *[]*trans.Transaction) error {
-	reply = &args
+	*reply = args
 	for _, cb := range h.beforeAll {
 		cb(args)
 	}
@@ -44,7 +44,7 @@ func (h *Hooks) RunBeforeAll(args []*trans.Transaction, reply *[]*trans.Transact
 }
 
 func (h *Hooks) RunBeforeEach(args trans.Transaction, reply *trans.Transaction) error {
-	reply = &args
+	*reply = args
 	for _, cb := range h.beforeEach {
 		cb(reply)
 	}
@@ -52,7 +52,7 @@ func (h *Hooks) RunBeforeEach(args trans.Transaction, reply *trans.Transaction) 
 }
 func (h *Hooks) RunBefore(args trans.Transaction, reply *trans.Transaction) error {
 	name := args.Name
-	reply = &args
+	*reply = args
 	for _, cb := range h.before[name] {
 		cb(reply)
 	}
@@ -60,7 +60,7 @@ func (h *Hooks) RunBefore(args trans.Transaction, reply *trans.Transaction) erro
 }
 
 func (h *Hooks) RunBeforeEachValidation(args trans.Transaction, reply *trans.Transaction) error {
-	reply = &args
+	*reply = args
 	for _, cb := range h.beforeEachValidation {
 		cb(reply)
 	}
@@ -68,7 +68,7 @@ func (h *Hooks) RunBeforeEachValidation(args trans.Transaction, reply *trans.Tra
 }
 func (h *Hooks) RunBeforeValidation(args trans.Transaction, reply *trans.Transaction) error {
 	name := args.Name
-	reply = &args
+	*reply = args
 	for _, cb := range h.beforeValidation[name] {
 		cb(reply)
 	}
@@ -77,7 +77,7 @@ func (h *Hooks) RunBeforeValidation(args trans.Transaction, reply *trans.Transac
 
 func (h *Hooks) RunAfter(args trans.Transaction, reply *trans.Transaction) error {
 	name := args.Name
-	reply = &args
+	*reply = args
 	for _, cb := range h.after[name] {
 		cb(reply)
 	}
@@ -85,7 +85,7 @@ func (h *Hooks) RunAfter(args trans.Transaction, reply *trans.Transaction) error
 }
 
 func (h *Hooks) RunAfterEach(args trans.Transaction, reply *trans.Transaction) error {
-	reply = &args
+	*reply = args
 	for _, cb := range h.afterEach {
 		cb(reply)
 	}
@@ -93,7 +93,7 @@ func (h *Hooks) RunAfterEach(args trans.Transaction, reply *trans.Transaction) e
 }
 
 func (h *Hooks) RunAfterAll(args []*trans.Transaction, reply *[]*trans.Transaction) error {
-	reply = &args
+	*reply = args
 	for _, cb := range h.afterAll {
 		cb(args)
 	}

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -45,6 +45,7 @@ func TestRunnerImplementation(t *testing.T) {
 	}
 	var hooks RunnerRPC
 	var invoked bool
+	reply := []*trans.Transaction{}
 	cbs := []Callback{
 		func(ts *trans.Transaction) {
 			invoked = true
@@ -60,7 +61,7 @@ func TestRunnerImplementation(t *testing.T) {
 			hooks = &Hooks{
 				beforeAll: allCbs,
 			}
-			hooks.RunBeforeAll([]*trans.Transaction{&tss}, nil)
+			hooks.RunBeforeAll([]*trans.Transaction{&tss}, &reply)
 		},
 		func() {
 			hooks = &Hooks{
@@ -111,7 +112,7 @@ func TestRunnerImplementation(t *testing.T) {
 			hooks = &Hooks{
 				afterAll: allCbs,
 			}
-			hooks.RunAfterAll([]*trans.Transaction{&tss}, nil)
+			hooks.RunAfterAll([]*trans.Transaction{&tss}, &reply)
 		},
 	}
 	for _, hookFn := range fns {

--- a/runner.go
+++ b/runner.go
@@ -24,13 +24,14 @@ type Run struct {
 	rpcService string
 }
 
-func (r *Run) RunBeforeAll(t []*transaction.Transaction) {
+func (r *Run) RunBeforeAll(t *[]*transaction.Transaction) {
 	var reply []*transaction.Transaction
 	err := r.client.Call(r.rpcService+".RunBeforeAll", t, &reply)
 
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunBeforeEach(t *transaction.Transaction) {
@@ -40,6 +41,7 @@ func (r *Run) RunBeforeEach(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunBefore(t *transaction.Transaction) {
@@ -49,6 +51,7 @@ func (r *Run) RunBefore(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunBeforeEachValidation(t *transaction.Transaction) {
@@ -58,6 +61,7 @@ func (r *Run) RunBeforeEachValidation(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunBeforeValidation(t *transaction.Transaction) {
@@ -67,15 +71,17 @@ func (r *Run) RunBeforeValidation(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
-func (r *Run) RunAfterAll(t []*transaction.Transaction) {
+func (r *Run) RunAfterAll(t *[]*transaction.Transaction) {
 	var reply []*transaction.Transaction
 	err := r.client.Call(r.rpcService+".RunAfterAll", t, &reply)
 
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunAfterEach(t *transaction.Transaction) {
@@ -85,6 +91,7 @@ func (r *Run) RunAfterEach(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) RunAfter(t *transaction.Transaction) {
@@ -94,6 +101,7 @@ func (r *Run) RunAfter(t *transaction.Transaction) {
 	if err != nil {
 		panic("RPC client threw error " + err.Error())
 	}
+	*t = reply
 }
 
 func (r *Run) Close() {
@@ -103,12 +111,12 @@ func (r *Run) Close() {
 }
 
 type Runner interface {
-	RunBeforeAll(t []*transaction.Transaction)
+	RunBeforeAll(t *[]*transaction.Transaction)
 	RunBeforeEach(t *transaction.Transaction)
 	RunBefore(t *transaction.Transaction)
 	RunBeforeEachValidation(t *transaction.Transaction)
 	RunBeforeValidation(t *transaction.Transaction)
-	RunAfterAll(t []*transaction.Transaction)
+	RunAfterAll(t *[]*transaction.Transaction)
 	RunAfterEach(t *transaction.Transaction)
 	RunAfter(t *transaction.Transaction)
 	Close()
@@ -116,7 +124,7 @@ type Runner interface {
 
 type DummyRunner struct{}
 
-func (r *DummyRunner) RunBeforeAll(t []*transaction.Transaction) {}
+func (r *DummyRunner) RunBeforeAll(t *[]*transaction.Transaction) {}
 
 func (r *DummyRunner) RunBeforeEach(t *transaction.Transaction) {}
 
@@ -126,7 +134,7 @@ func (r *DummyRunner) RunBeforeEachValidation(t *transaction.Transaction) {}
 
 func (r *DummyRunner) RunBeforeValidation(t *transaction.Transaction) {}
 
-func (r *DummyRunner) RunAfterAll(t []*transaction.Transaction) {}
+func (r *DummyRunner) RunAfterAll(t *[]*transaction.Transaction) {}
 
 func (r *DummyRunner) RunAfterEach(t *transaction.Transaction) {}
 

--- a/server.go
+++ b/server.go
@@ -95,7 +95,7 @@ func (server *Server) ProcessMessage(m *message) error {
 
 	switch m.Event {
 	case "beforeAll":
-		server.RunBeforeAll(m.transactions)
+		server.RunBeforeAll(&m.transactions)
 		break
 	case "beforeEach":
 		// before is run after beforeEach, as no separate event is fired.
@@ -110,11 +110,11 @@ func (server *Server) ProcessMessage(m *message) error {
 		break
 	case "afterEach":
 		// after is run before afterEach as no separate event is fired.
-		server.RunAfterEach(m.transaction)
 		server.RunAfter(m.transaction)
+		server.RunAfterEach(m.transaction)
 		break
 	case "afterAll":
-		server.RunAfterAll(m.transactions)
+		server.RunAfterAll(&m.transactions)
 		break
 	default:
 		return fmt.Errorf("Unknown event '%s'", m.Event)
@@ -130,7 +130,7 @@ func (server *Server) ProcessMessage(m *message) error {
 	}
 }
 
-func (server *Server) RunBeforeAll(trans []*t.Transaction) {
+func (server *Server) RunBeforeAll(trans *[]*t.Transaction) {
 	for _, runner := range server.Runner {
 		runner.RunBeforeAll(trans)
 	}
@@ -172,7 +172,7 @@ func (server *Server) RunAfter(trans *t.Transaction) {
 	}
 }
 
-func (server *Server) RunAfterAll(trans []*t.Transaction) {
+func (server *Server) RunAfterAll(trans *[]*t.Transaction) {
 	for _, runner := range server.Runner {
 		runner.RunAfterAll(trans)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -37,7 +37,21 @@ func TestSendingServerMessages(t *testing.T) {
 		},
 	}
 
-	conn, err := net.Dial("tcp", "localhost:61321")
+	var (
+		conn net.Conn
+		err  error
+	)
+
+	for {
+		// If server does not fail to start client should be able to connect.
+		// This is to prevent test from failing due to syncronization between
+		// server starting in go routine and client trying to connect.  This
+		// is a test, should probably pass a channel to server.Run instead.
+		conn, err = net.Dial("tcp", "localhost:61321")
+		if err == nil {
+			break
+		}
+	}
 
 	if err != nil {
 		t.Fatalf("Client connection to dredd hooks server failed")


### PR DESCRIPTION
@snikch I had an error in my code set the value instead of the pointers for the RPC clients which prevented the transaction structure in the hook callbacks from being mutated.
