### PR TITLE
New protagonist needs C++11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+sudo: required
+dist: trusty
 language: go
-
 install:
   - npm install
   - bundle install
-
 go_import_path: github.com/snikch/goodman
 script:
   - go test github.com/snikch/goodman/{,/transaction,/hooks}


### PR DESCRIPTION
To be able to install newer Dredd, one will need a C++ compiler able to compile C++11. In the future we will eventually migrate to js-only parser by default and no compiler will be needed, but as of now, this change is needed in order to make Dredd work with Travis CI.

https://github.com/apiaryio/protagonist/blob/master/CHANGELOG.md#breaking

We had the same problem at:
- https://github.com/apiaryio/dredd-hooks-python/
- https://github.com/apiaryio/dredd-hooks-ruby/

Exactly the same change fixed the builds.
