### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ The following are a few examples of what hooks can be used for:
 **Must use Dredd v1.1.0 or greater**
 
 ```bash
-go get github.com/snikch/goodman
-go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
+go get github.com/snikch/goodman/cmd/goodman
 ```
 
 ##Usage


### PR DESCRIPTION
The current install instructions are non standard (since go get is smart enough to install binaries).  This change is to update the install instructions to reflect what most Go programmers would expect for installing a package.
