### PR TITLE
Retry connection to hooks server

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -7,7 +7,7 @@ server:
 	go build -o server
 
 dredd: hooks/hooks server
-	 rm -f foo.db; touch foo.db; ../node_modules/.bin/dredd api.apib http://localhost:8080 --language go --server ./server --hookfiles hooks/hooks
+	rm -f foo.db; touch foo.db; ../node_modules/.bin/dredd api.apib http://localhost:8080 --language go --server ./server --hookfiles hooks/hooks
 
 clean: 
 	rm server hooks/hooks

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -9,7 +9,7 @@ type (
 	AllCallback func([]*trans.Transaction)
 )
 
-// Runner is responsible for storing and running lifecycle callbacks.
+// Hooks is responsible for storing and running lifecycle callbacks.
 type Hooks struct {
 	beforeAll            []AllCallback
 	beforeEach           []Callback
@@ -21,7 +21,7 @@ type Hooks struct {
 	afterAll             []AllCallback
 }
 
-// NewRunner returns a new Runner instance will all callback fields initialized.
+// NewHooks returns a new Hooks instance will all callback fields initialized.
 func NewHooks() *Hooks {
 	return &Hooks{
 		beforeAll:            []AllCallback{},

--- a/runner.go
+++ b/runner.go
@@ -7,16 +7,16 @@ import (
 	"github.com/snikch/goodman/transaction"
 )
 
-func NewRunner(rpcService string, port int) *Run {
+func NewRunner(rpcService string, port int) (*Run, error) {
 	client, err := rpc.DialHTTPPath("tcp", fmt.Sprintf(":%d", port), "/")
 
 	if err != nil {
-		panic(err.Error())
+		return nil, err
 	}
 	return &Run{
 		client:     client,
 		rpcService: rpcService,
-	}
+	}, nil
 }
 
 type Run struct {


### PR DESCRIPTION
Goodman currently waits 100 ms for the hooks server to start up, then tries to connect and panics with `panic: dial tcp :61322: getsockopt: connection refused` if it doesn't work.

This PR retries the connection up to 5 fives and waits 100 ms in between to improve robustness on slow machines.