### PR TITLE
Fix a data race between Cmd.Run and Process.Kill

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ env:
 install:
   - go get -u github.com/kardianos/govendor
   - go install github.com/kardianos/govendor
-  - go build -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
+  - go build -race -o $GOPATH/bin/goodman github.com/snikch/goodman/cmd/goodman
   - cd example && $GOPATH/bin/govendor sync && cd ..
 
 go_import_path: github.com/snikch/goodman

--- a/cmd/goodman/main.go
+++ b/cmd/goodman/main.go
@@ -34,7 +34,7 @@ func main() {
 		closeHooksServers()
 		os.Exit(0)
 	}()
-	hooksServerCount = len(args) - 1
+	hooksServerCount = len(hookPaths)
 	if len(args) < 2 {
 		runners = append(runners, &goodman.DummyRunner{})
 	} else {
@@ -45,11 +45,13 @@ func main() {
 			fmt.Println("Sending to channel\n")
 			cmds <- cmd
 			fmt.Println("Completed")
+			log.Printf("Starting hooks server")
+			if err := cmd.Start(); err != nil {
+				panic("Failed to start hooks server " + err.Error())
+			}
 			go func() {
-				log.Printf("Starting hooks server in go routine")
-				err := cmd.Run()
-				if err != nil {
-					fmt.Println("Hooks client failed with " + err.Error())
+				if err := cmd.Wait(); err != nil {
+					fmt.Println("Hooks server failed with " + err.Error())
 				}
 			}()
 			rpcService := reflect.TypeOf((*hooks.HooksRunner)(nil)).Elem().Name()


### PR DESCRIPTION
Replacing Cmd.Run with Cmd.Start + Cmd.Wait fixes the following data race:
```
==================
WARNING: DATA RACE
Read at 0x00c420062e60 by main goroutine:
  main.closeHooksServers()
      github.com/snikch/goodman/cmd/goodman/main.go:89 +0xd9
  main.main()
      github.com/snikch/goodman/cmd/goodman/main.go:82 +0xb56

Previous write at 0x00c420062e60 by goroutine 10:
  os/exec.(*Cmd).Start()
      /usr/local/go/src/os/exec/exec.go:354 +0x78c
  os/exec.(*Cmd).Run()
      /usr/local/go/src/os/exec/exec.go:277 +0x3c
  main.main.func2()
      github.com/snikch/goodman/cmd/goodman/main.go:50 +0x70

Goroutine 10 (running) created at:
  main.main()
      github.com/snikch/goodman/cmd/goodman/main.go:54 +0x6cc
==================
```