### PR TITLE
#32 - Do not omit 'skip' when false otherwise you cannot unskip transactions

### DIFF
--- a/features/step_definitions/dredd_steps.rb
+++ b/features/step_definitions/dredd_steps.rb
@@ -32,7 +32,7 @@ Then(/^I should receive same response$/) do
   sleep 1
   data_received = @client.readline
   if JSON.parse(data_received) != JSON.parse(@data_sent)
-    @client.close!
+    @client.close
     raise "Data received:\n#{data_received}\nDoesn't match data sent: #{@data_sent}\n"
   end
 end

--- a/features/tcp_server.feature
+++ b/features/tcp_server.feature
@@ -13,7 +13,7 @@ Scenario: Message exchange for event beforeEach
   And I connect to the server
   And I send a JSON message to the socket:
     """
-    {"event": "beforeEach", "uuid": "1234-abcd", "data": {}}
+    {"event": "beforeEach", "uuid": "1234-abcd", "data": {"skip":true}}
     """
   And I send a newline character as a message delimiter to the socket
   Then I should receive same response
@@ -25,7 +25,7 @@ Scenario: Message exchange for event beforeEachValidation
   And I connect to the server
   And I send a JSON message to the socket:
     """
-    {"event": "beforeEachValidation", "uuid": "2234-abcd", "data": {}}
+    {"event": "beforeEachValidation", "uuid": "2234-abcd", "data": {"skip":false}}
     """
   And I send a newline character as a message delimiter to the socket
   Then I should receive same response
@@ -37,7 +37,7 @@ Scenario: Message exchange for event afterEach
   And I connect to the server
   And I send a JSON message to the socket:
     """
-    {"event": "afterEach", "uuid": "3234-abcd", "data": {}}
+    {"event": "afterEach", "uuid": "3234-abcd", "data": {"skip":true}}
     """
   And I send a newline character as a message delimiter to the socket
   Then I should receive same response
@@ -49,7 +49,7 @@ Scenario: Message exchange for event beforeAll
   And I connect to the server
   And I send a JSON message to the socket:
     """
-    {"event": "beforeAll", "uuid": "4234-abcd", "data": []}
+    {"event": "beforeAll", "uuid": "4234-abcd", "data": [{"skip":false}]}
     """
   And I send a newline character as a message delimiter to the socket
   Then I should receive same response
@@ -61,7 +61,7 @@ Scenario: Message exchange for event afterAll
   And I connect to the server
   And I send a JSON message to the socket:
     """
-    {"event": "afterAll", "uuid": "5234-abcd", "data": []}
+    {"event": "afterAll", "uuid": "5234-abcd", "data": [{"skip":true}]}
     """
   And I send a newline character as a message delimiter to the socket
   Then I should receive same response

--- a/server_test.go
+++ b/server_test.go
@@ -21,19 +21,19 @@ func TestSendingServerMessages(t *testing.T) {
 		Payload []byte
 	}{
 		{
-			Payload: []byte("{\"uuid\":\"1234-abcd\",\"event\":\"beforeEach\",\"data\":{}}\n"),
+			Payload: []byte("{\"uuid\":\"1234-abcd\",\"event\":\"beforeEach\",\"data\":{\"skip\":false}}\n"),
 		},
 		{
-			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"beforeEachValidation\",\"data\":{}}\n"),
+			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"beforeEachValidation\",\"data\":{\"skip\":true}}\n"),
 		},
 		{
-			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"afterEach\",\"data\":{}}\n"),
+			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"afterEach\",\"data\":{\"skip\":false}}\n"),
 		},
 		{
-			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"beforeAll\",\"data\":[]}\n"),
+			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"beforeAll\",\"data\":[{\"skip\":true}]}\n"),
 		},
 		{
-			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"afterAll\",\"data\":[]}\n"),
+			Payload: []byte("{\"uuid\":\"2234-abcd\",\"event\":\"afterAll\",\"data\":[{\"skip\":false}]}\n"),
 		},
 	}
 

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -26,7 +26,7 @@ type Transaction struct {
 	Origin  *json.RawMessage `json:"origin,omitempty"`
 	Test    *json.RawMessage `json:"test,omitempty"`
 	Results *json.RawMessage `json:"results,omitempty"`
-	Skip    bool             `json:"skip,omitempty"`
+	Skip    bool             `json:"skip"`
 	Fail    interface{}      `json:"fail,omitempty"`
 
 	TestOrder []string `json:"hooks_modifications,omitempty"`


### PR DESCRIPTION
The inclusion of `omitempty` in the `Transaction` struct JSON encoding prevents the inclusion of `skip: false` in all hook responses.

This presents a problem when [you'd like to un-skip a transaction within a Before or After hook](https://github.com/snikch/goodman/issues/32).

Further explanation for this behavior is in [the Marshal documentation](https://golang.org/pkg/encoding/json/#Marshal):

> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.