### PR TITLE
Add 'expected' object for use in hooks

### DIFF
--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -17,8 +17,13 @@ type Transaction struct {
 		URI     string                 `json:"uri,omitempty"`
 		Method  string                 `json:"method,omitempty"`
 	} `json:"request,omitempty"`
-	Expected *json.RawMessage `json:"expected,omitempty"`
-	Real     *struct {
+	Expected *struct {
+		StatusCode string                 `json:"statusCode,omitempty"`
+		Body       string                 `json:"body,omitempty"`
+		Headers    map[string]interface{} `json:"headers,omitempty"`
+		Schema     *json.RawMessage       `json:"schema,omitempty"`
+	} `json:"expected,omitempty"`
+	Real *struct {
 		Body       string                 `json:"body"`
 		Headers    map[string]interface{} `json:"headers"`
 		StatusCode int                    `json:"statusCode"`


### PR DESCRIPTION
I'd like to be able to refer to expected status code and other things within my hook without having to manage my own `Expected` type definition and deal with marshalling JSON, etc.

This is nice:

```
if t.Expected.StatusCode == "401" {
    t.Request.Headers["Authorization"] = "Bearer utterNonsense"
}

```